### PR TITLE
chore: hoist eslint modules

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,3 +31,9 @@ hoist: false
 # Configure pnpm for non-monorepos
 packages:
   - "."
+
+# Hoist eslint plugins for compatibility
+publicHoistPattern:
+  - "eslint-plugin-*"
+  - "@eslint/*"
+  - "@typescript-eslint/*"


### PR DESCRIPTION
Added pattern to pnpm-workspace to hoist eslint node_modules to fix error when running eslint